### PR TITLE
onlpv1_%.bbappend: Remove do_install_append()

### DIFF
--- a/meta-mion-stordis/recipes-platform/onlpv1/onlpv1_%.bbappend
+++ b/meta-mion-stordis/recipes-platform/onlpv1/onlpv1_%.bbappend
@@ -38,9 +38,3 @@ EXTRA_OEMAKE_append = "\
 "
 
 COMPATIBLE_MACHINE="(stordis-bf2556x-1t|stordis-bf6064x-t)"
-
-do_install_append_bf2556x() {
-  # install platform.xml file
-  install -d ${D}/lib/platform-config/current/onl/
-  install -m 0664 packages/platforms/${ONIE_VENDOR}/${ONL_ARCH}/${ONL_MACHINE}/platform-config/r0/src/lib/platform.xml ${D}/lib/platform-config/current/onl/platform.xml
-}


### PR DESCRIPTION
This do_install_append is used to install the platform.xml file but is
not needed as this file is created as a symlink with the baseconf.py
script that is run by the baseconf service on startup.

Signed-off-by: John Toomey <john@toganlabs.com>