### PR TITLE
accton-wedge100bf-65x: fix init to wait for i2c

### DIFF
--- a/meta-mion-accton/recipes-platform/onlpv1/accton-wedge100bf-65x/0001-wedge100bf-65x-init.py-needs-to-wait-for-i2c.patch
+++ b/meta-mion-accton/recipes-platform/onlpv1/accton-wedge100bf-65x/0001-wedge100bf-65x-init.py-needs-to-wait-for-i2c.patch
@@ -1,0 +1,65 @@
+From 22e893cc8c1e94edfc67fcbaa8f134057bcf9473 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Eil=C3=ADs=20N=C3=AD=20Fhlannag=C3=A1in?=
+ <pidge@toganlabs.com>
+Date: Mon, 14 Dec 2020 20:11:13 +0000
+Subject: [PATCH] wedge100bf-65x: init.py needs to wait for i2c
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+the wedge was failing on boot as i2c wasn't availble yet. this
+waits for it to be there then continues
+
+Signed-off-by: Eilís Ní Fhlannagáin <pidge@toganlabs.com>
+---
+ .../__init__.py                               | 20 ++++++++++++++++++-
+ 1 file changed, 19 insertions(+), 1 deletion(-)
+
+diff --git a/packages/platforms/accton/x86-64/wedge100bf-65x/platform-config/r0/src/python/x86_64_accton_wedge100bf_65x_r0/__init__.py b/packages/platforms/accton/x86-64/wedge100bf-65x/platform-config/r0/src/python/x86_64_accton_wedge100bf_65x_r0/__init__.py
+index 9063bd71..c82bb353 100644
+--- a/packages/platforms/accton/x86-64/wedge100bf-65x/platform-config/r0/src/python/x86_64_accton_wedge100bf_65x_r0/__init__.py
++++ b/packages/platforms/accton/x86-64/wedge100bf-65x/platform-config/r0/src/python/x86_64_accton_wedge100bf_65x_r0/__init__.py
+@@ -1,6 +1,18 @@
+ from onl.platform.base import *
+ from onl.platform.accton import *
+ 
++
++import os
++import time
++
++def wait_for_file(path, timeout, interval=0.1):
++    start = time.time()
++    while not os.path.exists(path) and time.time() - start < timeout:
++        time.sleep(interval)
++    if time.time() - start > timeout and not os.path.exists(path):
++        raise Exception('Timed out waiting for file: "%s"' % path)
++
++
+ class OnlPlatform_x86_64_accton_wedge100bf_65x_r0(OnlPlatformAccton,
+                                                 OnlPlatformPortConfig_64x100):
+     MODEL="Wedge-100bf-65x"
+@@ -10,6 +22,10 @@ class OnlPlatform_x86_64_accton_wedge100bf_65x_r0(OnlPlatformAccton,
+     def baseconfig(self):
+         self.insmod('optoe')
+         
++        ''' Wait for i2c devices to come up before we write to them '''
++        for bus in [1, 2]:
++            wait_for_file('/sys/bus/i2c/devices/i2c-{}/new_device'.format(bus), timeout=10)
++
+         ########### initialize I2C bus 1 & bus 2 ###########
+         self.new_i2c_devices([
+          # initialize multiplexer (PCA9548)
+@@ -29,7 +45,9 @@ class OnlPlatform_x86_64_accton_wedge100bf_65x_r0(OnlPlatformAccton,
+ 
+                 ('24c64', 0x50, 41),
+                 ])
+-                
++
++        wait_for_file('/sys/bus/i2c/devices/i2c-41/new_device', timeout=10)
++
+         # Initialize QSFP devices
+         self.new_i2c_device('optoe1', 0x50, 3)
+         self.new_i2c_device('optoe1', 0x50, 4)
+-- 
+2.29.2
+

--- a/meta-mion-accton/recipes-platform/onlpv1/onlpv1_%.bbappend
+++ b/meta-mion-accton/recipes-platform/onlpv1/onlpv1_%.bbappend
@@ -44,6 +44,7 @@ SRC_URI_append_wedge100bf-65x = " \
     file://0001-i2c-bigcode-use-libi2c-for-onlpdump-and-update-headers.patch;patchdir=${SUBMODULE_BIGCODE} \
     file://0001-i2c-infra-use-libi2c-for-onlpdump-and-update-headers.patch;patchdir=${SUBMODULE_INFRA} \
     file://0001-i2c-use-libi2c-for-onlpdump-and-update-headers.patch \
+    file://0001-wedge100bf-65x-init.py-needs-to-wait-for-i2c.patch \
 "
 
 MODULE_asgvolt64 = "x86_64_accton_asgvolt64"


### PR DESCRIPTION
i2c devices weren't getting created fast enough causing issues on
the wedge100bf-65x. We've not tested this on the 35x, but the
issue may exist there as well.

Signed-off-by: Eilís Ní Fhlannagáin <pidge@toganlabs.com>