### PR TITLE
onlpv1_%.bbappend: Remove irq_debug from bf6064x

### DIFF
--- a/meta-mion-stordis/recipes-platform/onlpv1/onlpv1_%.bbappend
+++ b/meta-mion-stordis/recipes-platform/onlpv1/onlpv1_%.bbappend
@@ -27,6 +27,7 @@ SRC_URI_append = " \
 
 SRC_URI_append_bf6064x = " \
     file://0001-Makefile-Add-FILTER-from-src-to-machine-name.patch \
+    file://remove_irq_debug.patch \
 "
 
 

--- a/meta-mion-stordis/recipes-platform/onlpv1/stordis-bf6064x-t/remove_irq_debug.patch
+++ b/meta-mion-stordis/recipes-platform/onlpv1/stordis-bf6064x-t/remove_irq_debug.patch
@@ -1,0 +1,10 @@
+diff --git a/packages/platforms/stordis/x86-64/bf6064x-t/platform-config/r0/src/python/x86_64_stordis_bf6064x_t_r0/__init__.py b/packages/platforms/stordis/x86-64/bf6064x-t/platform-config/r0/src/python/x86_64_stordis_bf6064x_t_r0/__init__.py
+index be64b848..bd0ca96d 100755
+--- a/packages/platforms/stordis/x86-64/bf6064x-t/platform-config/r0/src/python/x86_64_stordis_bf6064x_t_r0/__init__.py
++++ b/packages/platforms/stordis/x86-64/bf6064x-t/platform-config/r0/src/python/x86_64_stordis_bf6064x_t_r0/__init__.py
+@@ -9,5 +9,4 @@ class OnlPlatform_x86_64_stordis_bf6064x_t_r0(OnlPlatformStordis,
+     SYS_OBJECT_ID = ".6064"
+ 
+     def baseconfig(self):
+-        self.insmod('irq_debug')
+         return True


### PR DESCRIPTION
irq_debug is causing all sorts of issues for the bf6064x and
needs to be looked at. Removing for now until it's fixed

Signed-off-by: Eilís Ní Fhlannagáin <pidge@toganlabs.com>