### PR TITLE
Revert APS Networks remotes

### DIFF
--- a/meta-mion-stordis/recipes-platform/onlpv1/onlpv1_%.bbappend
+++ b/meta-mion-stordis/recipes-platform/onlpv1/onlpv1_%.bbappend
@@ -14,8 +14,8 @@ SRCREV_bigcode_bf6064x = "94091600faa76fac492b4be2ffab17cb9788d697"
 ONL_BRANCH_bf2556x = "main"
 ONL_BRANCH_bf6064x = "main"
 
-URI_ONL_bf2556x = "git://github.com/apsnw/OpenNetworkLinux.git;branch=${ONL_BRANCH}"
-URI_ONL_bf6064x = "git://github.com/apsnw/OpenNetworkLinux.git;branch=${ONL_BRANCH}"
+URI_ONL_bf2556x = "git://github.com/APS-Networks/OpenNetworkLinux.git;branch=${ONL_BRANCH}"
+URI_ONL_bf6064x = "git://github.com/APS-Networks/OpenNetworkLinux.git;branch=${ONL_BRANCH}"
 
 TARGET_CFLAGS_bf6064x += "-Wno-error -Wno-error=restrict -Wno-error=format-overflow -Wno-error=cpp"
 

--- a/meta-mion-stordis/recipes-platform/onlpv2/onlpv2_%.bbappend
+++ b/meta-mion-stordis/recipes-platform/onlpv2/onlpv2_%.bbappend
@@ -6,8 +6,8 @@ FILESEXTRAPATHS_prepend_bf6064x := "${THISDIR}/${MACHINE}:"
 ONL_BRANCH_bf2556x = "main"
 ONL_BRANCH_bf6064x = "main"
 
-URI_ONL_bf2556x = "git://github.com/apsnw/OpenNetworkLinuxv2.git;branch=${ONL_BRANCH}"
-URI_ONL_bf6064x = "git://github.com/apsnw/OpenNetworkLinuxv2.git;branch=${ONL_BRANCH}"
+URI_ONL_bf2556x = "git://github.com/APS-Networks/OpenNetworkLinuxv2.git;branch=${ONL_BRANCH}"
+URI_ONL_bf6064x = "git://github.com/APS-Networks/OpenNetworkLinuxv2.git;branch=${ONL_BRANCH}"
 
 MODULE_bf2556x="x86_64_stordis_bf2556x_1t"
 MODULE_bf6064x="x86_64_stordis_bf6064x_t"


### PR DESCRIPTION
APS Networks account changed to the name of a deleted account that held the desired name.

Signed-off-by: G Davey <gdavey@committhis.co.uk>