### PR TITLE
meta-mion-stordis/conf/machine/*: Add platform service

### DIFF
--- a/meta-mion-stordis/conf/machine/stordis-bf2556x-1t.conf
+++ b/meta-mion-stordis/conf/machine/stordis-bf2556x-1t.conf
@@ -26,8 +26,7 @@ CONSOLE_PORT = "0x3f8"
 
 GLIBC_ADDONS = "nptl"
 
-#MACHINE_EXTRA_RDEPENDS += "x86-64-stordis-bf2556x-1t-ir2_debug-1-mod"
-MACHINE_EXTRA_RDEPENDS += "platform-stordis-bf2556x-1t"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "platform-stordis-bf2556x-1t"
 
 ONIE_VENDOR = "stordis"
 

--- a/meta-mion-stordis/conf/machine/stordis-bf6064x-t.conf
+++ b/meta-mion-stordis/conf/machine/stordis-bf6064x-t.conf
@@ -26,8 +26,7 @@ CONSOLE_PORT = "0x3f8"
 
 GLIBC_ADDONS = "nptl"
 
-#MACHINE_EXTRA_RDEPENDS += "x86-64-stordis-bf2556x-1t-ir2_debug-1-mod"
-MACHINE_EXTRA_RDEPENDS += "platform-stordis-bf6064x-t"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "platform-stordis-bf6064x-t"
 
 ONIE_VENDOR = "stordis"
 


### PR DESCRIPTION
This should be MACHINE_ESSENTIAL_EXTRA_RDEPENDS not
MACHINE_EXTRA_RDEPENDS

Signed-off-by: Eilís Ní Fhlannagáin <pidge@toganlabs.com>