### PR TITLE
Remove redundant clock source set from init script

### DIFF
--- a/meta-mion-stordis/recipes-platform/platform-stordis-bf6064x-t/files/platform-stordis-bf6064x-t-init.sh
+++ b/meta-mion-stordis/recipes-platform/platform-stordis-bf6064x-t/files/platform-stordis-bf6064x-t-init.sh
@@ -2,10 +2,6 @@
 
 # SPDX-License-Identifier: MIT 
 
-function set_clocksouce() {
-	echo tsc > /sys/devices/system/clocksource/clocksource0/current_clocksource
-}
-
 function enable_tx() {
 	# Set Module TX-Disable Registers
 	i2cset -y 0 0x70 0x20
@@ -39,5 +35,4 @@ function wait_for_file() {
 	return 1
 }
 
-wait_for_file /sys/bus/i2c/devices/0-0069 && set_clocksouce
 wait_for_file /sys/bus/i2c/devices/i2c-0 && enable_tx


### PR DESCRIPTION
It looks like this clock source is being set correctly, even with this
line commented out so it seems safe to remove it. It is only here
because this init script is based on the code used by the 2556 switch.

Signed-off-by: John Toomey <john@toganlabs.com>

# meta-mion-bsp

## Summary
- Description: _brief description of the bug that was fixed or the enhancement that was added_
- Affected hardware: _ALL -or- list specific switches_
- Issue: #59 

## Build and test
- [ ] Build command: n/a
- [x] Smoke tested on: 6064