### PR TITLE
barefoot-bsp_9.4.0: Add bbappend for 6064

### DIFF
--- a/meta-mion-stordis/recipes-drivers/barefoot-bsp/barefoot-bsp_9.4.0.bbappend
+++ b/meta-mion-stordis/recipes-drivers/barefoot-bsp/barefoot-bsp_9.4.0.bbappend
@@ -1,0 +1,12 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${MACHINE}:"
+
+BSP_PLATFORM_CODE_stordis-bf2556x-1t = "bf-reference-bsp-9.4.0-BF2556_1.0.2"
+BSP_PLATFORM_CODE_stordis-bf6064x-t = "bf-reference-bsp-9.4.0-BF6064_1.0.1"
+
+SRC_URI_stordis-bf2556x-1t = "file://0001-Remove-host-includes.patch;patchdir=${WORKDIR}/git/bf-platforms-${SDE_VERSION}"
+
+
+EXTRA_OECONF_stordis-bf2556x-1t += "--prefix=${STAGING_DIR} --with-tof-brgup-plat --with-libtool-sysroot=${STAGING_DIR}"
+EXTRA_OECONF_stordis-bf6064x-t += "--prefix=${STAGING_DIR} --with-libtool-sysroot=${STAGING_DIR}"
+COMPATIBLE_MACHINE = "(stordis-bf2556x-1t|stordis-bf6064x-t)"
+

--- a/meta-mion-stordis/recipes-drivers/barefoot-bsp/stordis-bf2556x-1t/0001-Remove-host-includes.patch
+++ b/meta-mion-stordis/recipes-drivers/barefoot-bsp/stordis-bf2556x-1t/0001-Remove-host-includes.patch
@@ -1,0 +1,55 @@
+From c5f498953456dc54a3f058d9e61b7ca88a334541 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Eil=C3=ADs=20N=C3=AD=20Fhlannag=C3=A1in?=
+ <pidge@toganlabs.com>
+Date: Fri, 26 Feb 2021 16:03:36 +0000
+Subject: [PATCH] Remove host includes
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Eilís Ní Fhlannagáin <pidge@toganlabs.com>
+---
+ platforms/apsn/cp2112_util/Makefile.am     | 2 +-
+ platforms/apsn/diags/mavericks/Makefile.am | 2 +-
+ platforms/apsn/tofino_spi_util/Makefile.am | 2 +-
+ 4 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/platforms/apsn/cp2112_util/Makefile.am b/platforms/apsn/cp2112_util/Makefile.am
+index 08749a5..5c090c7 100644
+--- a/platforms/apsn/cp2112_util/Makefile.am
++++ b/platforms/apsn/cp2112_util/Makefile.am
+@@ -1,6 +1,6 @@
+ bin_PROGRAMS = cp2112_util
+ cp2112_util_CFLAGS = $(AM_CFLAGS) $(BFPLATFORMS_CFLAGS)
+-cp2112_util_CPPFLAGS = -I$(includedir) -I$(top_srcdir)/drivers/include/ -I$(top_srcdir)/platforms/include -I$(top_srcdir)/platforms/apsn/include/ -DDEVICE_IS_ASIC
++cp2112_util_CPPFLAGS = -I$(top_srcdir)/drivers/include/ -I$(top_srcdir)/platforms/include -I$(top_srcdir)/platforms/apsn/include/ -DDEVICE_IS_ASIC
+ 
+ cp2112_util_SOURCES = \
+ cp2112_util.c \
+diff --git a/platforms/apsn/diags/mavericks/Makefile.am b/platforms/apsn/diags/mavericks/Makefile.am
+index ba7efe2..1638d1a 100644
+--- a/platforms/apsn/diags/mavericks/Makefile.am
++++ b/platforms/apsn/diags/mavericks/Makefile.am
+@@ -1,6 +1,6 @@
+ lib_LTLIBRARIES = libaccton_mav_diags.la
+ 
+-AM_CPPFLAGS += -I$(includedir) -I$(srcdir)/../../include
++AM_CPPFLAGS += -I$(srcdir)/../../include
+ 
+ libaccton_mav_diags_la_CFLAGS = $(AM_CFLAGS) $(BFPLATFORMS_CFLAGS)
+ libaccton_mav_diags_la_CPPFLAGS = -I$(top_builddir)/p4-build $(AM_CPPFLAGS)
+diff --git a/platforms/apsn/tofino_spi_util/Makefile.am b/platforms/apsn/tofino_spi_util/Makefile.am
+index 8e3a642..4ea269c 100644
+--- a/platforms/apsn/tofino_spi_util/Makefile.am
++++ b/platforms/apsn/tofino_spi_util/Makefile.am
+@@ -1,6 +1,6 @@
+ bin_PROGRAMS = spi_i2c_util
+ spi_i2c_util_CFLAGS = $(AM_CFLAGS) $(BFPLATFORMS_CFLAGS)
+-spi_i2c_util_CPPFLAGS = -I$(includedir) -I$(top_srcdir)/drivers/include/ -I$(top_srcdir)/platforms/include -I$(top_srcdir)/platforms/apsn/include/ -DDEVICE_IS_ASIC
++spi_i2c_util_CPPFLAGS = -I$(top_srcdir)/drivers/include/ -I$(top_srcdir)/platforms/include -I$(top_srcdir)/platforms/apsn/include/ -DDEVICE_IS_ASIC
+ 
+ spi_i2c_util_SOURCES = \
+ tofino_spi_if.c \
+-- 
+2.30.0
+


### PR DESCRIPTION
We need a different BSP_PLATFORM_CODE and compiler
flags for the 6064

Signed-off-by: Eilís Ní Fhlannagáin <pidge@toganlabs.com>

# meta-mion-bsp

## Summary
- Description: _brief description of the bug that was fixed or the enhancement that was added_
- Affected hardware: _ALL -or- list specific switches_
- Issue: _#?_

## Build and test
- [ ] Build command: _e.g. mc_build.sh ..._
- [ ] Smoke tested on: _e.g. stordis bf2556x-1t_
- [ ] _all other steps taken to validate the pull request_

## Checklist
- [ ] All relevant issues have been updated
- [ ] Reviewers have been added and a maintainer has been assigned
- [ ] A Label, Project and Milestone have all been added
- [ ] The relevant documentation/wiki/README have been updated and complies with the [NGL Style and Communication Guide](https://github.com/NetworkGradeLinux/mion-docs/wiki/Style-and-Communication-Guide)
- [ ] Git commits comply with the [NGL Git Workflow](https://github.com/NetworkGradeLinux/mion-docs/wiki/Git-Workflow) and have DCO signoff
- [ ] Yocto code complies with the [OpenEmbedded Style Guide](https://www.openembedded.org/wiki/Styleguide)
