### PR TITLE
barefoot-bsp_9.4.0.bbappend: appends before machine

### DIFF
--- a/meta-mion-stordis/recipes-drivers/barefoot-bsp/barefoot-bsp_9.4.0.bbappend
+++ b/meta-mion-stordis/recipes-drivers/barefoot-bsp/barefoot-bsp_9.4.0.bbappend
@@ -3,8 +3,8 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${MACHINE}:"
 BSP_PLATFORM_CODE_stordis-bf2556x-1t = "bf-reference-bsp-9.4.0-BF2556_1.0.2"
 BSP_PLATFORM_CODE_stordis-bf6064x-t = "bf-reference-bsp-9.4.0-BF6064_1.0.1"
 
-SRC_URI_stordis-bf2556x-1t = "file://0001-Remove-host-includes.patch;patchdir=${WORKDIR}/git/bf-platforms-${SDE_VERSION}"
-SRC_URI_stordis-bf6064x-t = "file://0001-Remove-host-includes.patch;patchdir=${WORKDIR}/git/bf-platforms-${SDE_VERSION}"
+SRC_URI_append_stordis-bf2556x-1t = "file://0001-Remove-host-includes.patch;patchdir=${WORKDIR}/git/bf-platforms-${SDE_VERSION}"
+SRC_URI_append_stordis-bf6064x-t = "file://0001-Remove-host-includes.patch;patchdir=${WORKDIR}/git/bf-platforms-${SDE_VERSION}"
 
 
 EXTRA_OECONF_stordis-bf2556x-1t += "--prefix=${STAGING_DIR} --with-tof-brgup-plat --with-libtool-sysroot=${STAGING_DIR}"


### PR DESCRIPTION
We need to append the SRC_URI before the machine else SRC_URI gets clobbered

Signed-off-by: Eilís Ní Fhlannagáin <pidge@toganlabs.com>

# meta-mion-bsp

## Summary
- Description: _brief description of the bug that was fixed or the enhancement that was added_
- Affected hardware: _ALL -or- list specific switches_
- Issue: _#?_

## Build and test
- [ ] Build command: _e.g. mc_build.sh ..._
- [ ] Smoke tested on: _e.g. stordis bf2556x-1t_
- [ ] _all other steps taken to validate the pull request_

## Checklist
- [ ] All relevant issues have been updated
- [ ] Reviewers have been added and a maintainer has been assigned
- [ ] A Label, Project and Milestone have all been added
- [ ] The relevant documentation/wiki/README have been updated and complies with the [NGL Style and Communication Guide](https://github.com/NetworkGradeLinux/mion-docs/wiki/Style-and-Communication-Guide)
- [ ] Git commits comply with the [NGL Git Workflow](https://github.com/NetworkGradeLinux/mion-docs/wiki/Git-Workflow) and have DCO signoff
- [ ] Yocto code complies with the [OpenEmbedded Style Guide](https://www.openembedded.org/wiki/Styleguide)
